### PR TITLE
Assigns query to a new variable

### DIFF
--- a/lib/client_searcher.rb
+++ b/lib/client_searcher.rb
@@ -1,6 +1,6 @@
 class ClientSearcher
   def self.search_by_name(clients, query)
-    query.downcase!
+    query = query.downcase
     clients.select do |client|
       client.full_name.downcase.include?(query)
     end


### PR DESCRIPTION
This pull request includes a minor change to the `search_by_name` method in the `ClientSearcher` class. The change ensures that the `query` variable is not mutated during the downcasing process.

* [`lib/client_searcher.rb`](diffhunk://#diff-87f5a408afa03f111936375188c890a1f687c36ad0600dfb072a090a9fb53554L3-R3): Replaced the in-place `downcase!` method with an assignment to `query.downcase` to avoid mutating the original `query` object.